### PR TITLE
fix: fixed Conditionally Include ip_configuration_id for Dynamic NAT Rules only

### DIFF
--- a/modules/nat-rules/main.tf
+++ b/modules/nat-rules/main.tf
@@ -5,8 +5,10 @@ resource "azurerm_virtual_network_gateway_nat_rule" "rules" {
   mode                       = each.value.mode
   type                       = each.value.type
   virtual_network_gateway_id = try(each.value.virtual_network_gateway_id, var.virtual_network_gateway_id)
-  ip_configuration_id        = each.value.ip_configuration_id
-  resource_group_name        = var.resourcegroup
+  # Conditionally assign ip_configuration_id only if the type is "Dynamic"
+  ip_configuration_id = each.value.type == "Dynamic" ? each.value.ip_configuration_id : null
+
+  resource_group_name = var.resourcegroup
 
   external_mapping {
     address_space = each.value.external_mappings.address_space


### PR DESCRIPTION


## Description

This PR modifies the azurerm_virtual_network_gateway_nat_rule resource to conditionally include the ip_configuration_id attribute only when the NAT rule type is "Dynamic". This change prevents errors caused by specifying ip_configuration_id for Static NAT rules.


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #22 
